### PR TITLE
Show selected properly; dont add .html to links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,9 +13,9 @@
       <a href="#main-content">Jump to main content</a>
     </span>
     <ul class="p-navigation__links">
-      <li class="p-navigation__link{% if page.url == '/documentation' %} is-selected{% endif %}"><a href="/documentation.html">Documentation</a></li>
+      <li class="p-navigation__link{% if page.url == '/documentation.html' %} is-selected{% endif %}"><a href="/documentation">Documentation</a></li>
       <li class="p-navigation__link{% if page.url == '/design.html' %} is-selected{% endif %}"><a href="/design">Design</a></li>
-      <li class="p-navigation__link{% if page.url == '/faq' %} is-selected{% endif %}"><a href="/faq.html">FAQ</a></li>
+      <li class="p-navigation__link{% if page.url == '/faq.html' %} is-selected{% endif %}"><a href="/faq">FAQ</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
Our links should never contain `.html`.

But the `page.url` should match ".html" so the "selected page" shows up properly.

QA
--

``` bash
./run
```

Go to http://0.0.0.0:8024, click around the top nav. Check you never end up on a `.html` URL, and that the correct part of the navigation shows as active.