### PR TITLE
Add Dockerfile for building production containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:xenial
+
+RUN apt-get update && apt-get install --yes nginx
+
+# Set git commit ID
+ARG COMMIT_ID
+ENV COMMIT_ID=$COMMIT_ID
+RUN test -n "${COMMIT_ID}"
+
+# Copy over files
+WORKDIR /srv
+ADD _site .
+ADD nginx.conf /etc/nginx/sites-enabled/default
+RUN sed -i "s/~COMMIT_ID~/${COMMIT_ID}/" /etc/nginx/sites-enabled/default
+
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,3 +14,4 @@ layout: compress
     {% include footer.html %}
   </body>
 </html>
+<!-- Comment edited 2018-02-20 19:05:55 GMT -->

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,48 @@
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    root /srv;
+    index index.html;
+
+    # Log to stdout
+    access_log /dev/stdout;
+    error_log /dev/stderr info;
+
+    # Show 404 page
+    error_page 404 /404.html;
+
+    # Show commit-id
+    add_header X-Commit-ID ~COMMIT_ID~ always;
+    add_header X-Hostname $hostname always;
+
+    server_name _;
+
+    # Remove .html extension from URLs
+    if ($request_uri ~ ^/(.*)\.html$) {
+        return 301 /$1;
+    }
+
+    # Remove index or index.html from URIs
+    if ($request_uri ~ ^.*/index(.html)?$) {
+        rewrite ^(.*/)index(.html)? $1 permanent;
+    }
+
+    # Remove slashes form URIs if it's not a directory
+    if (!-d $request_filename) {
+        rewrite ^/(.*)/$ /$1 permanent;
+    }
+
+    # Add slashes from URIs if it's a directory
+    if (-d $request_filename) {
+        rewrite ^/(.*[^/])$ /$1/ permanent;
+    }
+
+    # For finding files from URIs
+    # First try the URI directly, then try adding .html, then try treating it as a directory
+    # Finally fall back to 404
+    location ~ ^/.+$ {
+        try_files $uri $uri.html $uri/ =404;
+    }
+}
+


### PR DESCRIPTION
Fixes #3

QA
--

``` bash
./run build  # Build the site
docker build --build-arg COMMIT_ID=`git rev-parse HEAD` --tag netplan .  # Build the image
docker run -p 80:80 netplan  # Run the site container
```

Now visit http://localhost. Check the site works. Check also that redirects happen:

- http://localhost/index -> http://localhost
- http://localhost/index.html -> http://localhost
- http://localhost/documentation/ -> http://localhost/documentation
- http://localhost/documentation.html -> http://localhost/documentation