### PR TITLE
Add help links on footer, based on maas.io.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,4 +1,47 @@
 <footer class="p-footer u-no-margin--top">
+    <div class="row">
+        <div class="col-4">
+            <h3 class="p-footer__title p-heading--six">Netplan</h3>
+            <ul class="p-footer__list p-list">
+                <li class="p-list__item">
+                    <a class="p-link--strong" href="/">Home</a>
+                </li>
+                <li class="p-list__item">
+                    <a class="p-link--strong" href="/reference">Reference</a>
+                </li>
+                <li class="p-list__item">
+                    <a class="p-link--strong" href="/design">Design</a>
+                </li>
+                <li class="p-list__item">
+                    <a class="p-link--strong"  href="/examples">Examples</a>
+                </li>
+            </ul>
+        </div>
+
+        <div class="col-4">
+            <h3 class="p-footer__title p-heading--six">Need help?</h3>
+            <ul class="p-footer__list p-list">
+                <li class="p-list__item">
+                    <a class="p-link--external p-link--strong" href="https://askubuntu.com/questions/tagged/netplan">Ask Ubuntu</a>
+                </li>
+                <li class="p-list__item">
+                    <a class="p-link--external p-link--strong" href="http://webchat.freenode.net/?channels=netplan">Chat with Netplan on freenode</a>
+                </li>
+                <li class="p-footer__item">
+                    <a class="p-link--external p-link--strong" href="https://launchpad.net/netplan/+filebug">Report a bug</a>
+                </li>
+            </ul>
+        </div>
+
+        <div class="col-4">
+            <h3 class="p-footer__title p-heading--six">Contribute</h3>
+            <ul class="p-footer__list p-list">
+                <li class="p-list__item">
+                    <a class="p-link--external p-link--strong" href="https://github.com/CanonicalLtd/netplan">Github</a>
+                </li>
+            </ul>
+        </div>
+    </div>
   <div class="row">
     <div class="col-12">
       &copy; {{ "now" | date: "%Y" }} Canonical Ltd. Ubuntu and Canonical are registered trademarks of Canonical Ltd.


### PR DESCRIPTION
## Done

Add help links -- specifically for AskUbuntu

## QA

Footer on all pages should list Netplan, Help, and Contribute columns.
