### PR TITLE
Fix textwrapping on reference and design examples

### DIFF
--- a/design.html
+++ b/design.html
@@ -103,13 +103,14 @@ source: https://wiki.ubuntu.com/Netplan/Design
 <code>network:
   version: 2
 
-  # if specified globally, can only realistically have that value, as networkd cannot
-  # render wifi/3G. This would be shipped as a separate config.d/ by desktop images.
-  # it can also be specified by-type or by-device
+  # if specified globally, can only realistically have that value, as
+  # networkd cannot render wifi/3G. This would be shipped as a separate
+  # config.d/ by desktop images. it can also be specified by-type or
+  # by-device
   #renderer: NetworkManager
   ethernets:
-    # opaque ID for physical interfaces with match rules, only referred to by
-    # other stanzas
+    # opaque ID for physical interfaces with match rules, only referred to
+    # by other stanzas
     id0:
       match:
       macaddress: 00:11:22:33:44:55
@@ -128,21 +129,22 @@ source: https://wiki.ubuntu.com/Netplan/Design
       set-name: lom1
       dhcp6: true
     switchports:
-      # all cards on second PCI bus; unconfigured by themselves, will be added
-      # to br0 below
+      # all cards on second PCI bus; unconfigured by themselves, will be
+      # added to br0 below
       match:
         name: enp2*
       mtu: 1280
     wifis:
       all-wlans:
-      # useful on a system where you know there is only ever going to be one device
+      # useful on a system where you know there is only
+      # ever going to be one device
       match: {}
       access-points:
         "Joe's home":
           # mode defaults to "managed" (client), key type to wpa-psk
           password: "s3kr1t"
-      # this creates an AP on wlp1s0 using hostapd; no match rules, thus ID
-      # is the interface name
+      # this creates an AP on wlp1s0 using hostapd;
+      # no match rules, thus ID is the interface name
       wlp1s0:
         access-points:
           "guest":
@@ -154,7 +156,8 @@ source: https://wiki.ubuntu.com/Netplan/Design
       # the key name is the name for virtual (created) interfaces;
       # no 'match' or 'set-name' attributes are allowed.
       br0:
-        # IDs of the components; switchports expands into multiple interfaces
+        # IDs of the components; switchports expands into
+        # multiple interfaces
         interfaces: [wlp1s0, switchports]
         dhcp4: true
       routes:

--- a/reference.md
+++ b/reference.md
@@ -177,7 +177,7 @@ Virtual devices
     requires setting ``addresses`` too. Gateway IPs must be in a form
     recognized by **``inet_pton``**(3).
 
-    Example for IPv4: ``gateway4: 172.16.0.1``  
+    Example for IPv4: ``gateway4: 172.16.0.1``
     Example for IPv6: ``gateway6: "2001:4::1"``
 
 ``nameservers`` (mapping)
@@ -630,14 +630,16 @@ This is a complex example which shows most available features:
           set-name: lom1
           dhcp6: true
         switchports:
-          # all cards on second PCI bus; unconfigured by themselves, will be added
-          # to br0 below (note: globbing is not supported by NetworkManager)
+          # all cards on second PCI bus; unconfigured by themselves, will be
+          # added to br0 below
+          # note: globbing is not supported by NetworkManager
           match:
             name: enp2*
           mtu: 1280
       wifis:
         all-wlans:
-          # useful on a system where you know there is only ever going to be one device
+          # useful on a system where you know there is only ever going to be
+          # one device
           match: {}
           access-points:
             "Joe's home":
@@ -651,8 +653,8 @@ This is a complex example which shows most available features:
                mode: ap
                # no WPA config implies default of open
       bridges:
-        # the key name is the name for virtual (created) interfaces; no match: and
-        # set-name: allowed
+        # the key name is the name for virtual (created) interfaces; no match:
+        # and set-name: allowed
         br0:
           # IDs of the components; switchports expands into multiple interfaces
           interfaces: [wlp1s0, switchports]


### PR DESCRIPTION
The code examples have text in comments that wrap to the next line. The
result is text that looks misleading and confusing by having a single
word stick out to the next line.

Similar to other long, multi-line comments this moves words or phrases
to the next line to prevent the wrapping.

Fixes #24

## Done

Verify inline code comments do not line wrap
A few white space changes were also picked up.

## QA

Used ./run to verify fixes

## Issue / Card

Fixes #24
