### PR TITLE
Add curtin v1 YAML link

### DIFF
--- a/design.html
+++ b/design.html
@@ -63,7 +63,7 @@ source: https://wiki.ubuntu.com/Netplan/Design
 
       <h2>Network Config format</h2>
 
-      <p>This is called "version 2", as current MAAS/curtin already use a (different) YAML format that is called "version 1".</p>
+      <p>This is called "version 2", as current MAAS/curtin already use a <a class="p-link--external" href="http://curtin.readthedocs.io/en/latest/topics/networking.html">different YAML format</a> that is called "version 1".</p>
 
       <h2>General structure</h2>
 


### PR DESCRIPTION
Adds in a link to the curtin v1 YAML link format.

Fixes #25

## Done

Add in a link to curtin's read the docs on networking config format.

## QA

Used ./run to verify change and link.

## Issue / Card

Fixes #25 
